### PR TITLE
Get tests green

### DIFF
--- a/clientSideRedirect.js
+++ b/clientSideRedirect.js
@@ -10,7 +10,7 @@ module.exports = function getMetaRedirect(toPath) {
       url = `/${url}`;
     }
     
-    if(hasTrailingSlash) {
+    if (hasTrailingSlash && url.length > 1) {
       url = url.slice(0, -1);
     }
 

--- a/tests/__snapshots__/clientSideRedirect.spec.js.snap
+++ b/tests/__snapshots__/clientSideRedirect.spec.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`clientSideRedirect allows existing leading and trailing forward slashes 1`] = `"<script>window.location.href=\\"/toPath/\\"</script>"`;
+exports[`clientSideRedirect allows existing leading and trailing forward slashes 1`] = `"<script>window.location.href=\\"/toPath\\"</script>"`;
 
-exports[`clientSideRedirect handles deep paths 1`] = `"<script>window.location.href=\\"/a/b/c/d/\\"</script>"`;
+exports[`clientSideRedirect handles deep paths 1`] = `"<script>window.location.href=\\"/a/b/c/d\\"</script>"`;
 
-exports[`clientSideRedirect handles offset wrapping forward slashes 1`] = `"<script>window.location.href=\\"/a/b/c/\\"</script>"`;
+exports[`clientSideRedirect handles offset wrapping forward slashes 1`] = `"<script>window.location.href=\\"/a/b/c\\"</script>"`;
 
 exports[`clientSideRedirect handles redirecting to a file 1`] = `"<script>window.location.href=\\"/test.txt\\"</script>"`;
 
@@ -18,8 +18,8 @@ exports[`clientSideRedirect leaves full urls untouched 2`] = `"<script>window.lo
 
 exports[`clientSideRedirect leaves full urls untouched 3`] = `"<script>window.location.href=\\"http://example.com/a/b/c\\"</script>"`;
 
-exports[`clientSideRedirect replaces duplicate slashes with single slash 1`] = `"<script>window.location.href=\\"/topath/a/\\"</script>"`;
+exports[`clientSideRedirect replaces duplicate slashes with single slash 1`] = `"<script>window.location.href=\\"/topath/a\\"</script>"`;
 
-exports[`clientSideRedirect trims leading and trailing whitespace 1`] = `"<script>window.location.href=\\"/toPath/\\"</script>"`;
+exports[`clientSideRedirect trims leading and trailing whitespace 1`] = `"<script>window.location.href=\\"/toPath\\"</script>"`;
 
-exports[`clientSideRedirect wraps path in forward slashes 1`] = `"<script>window.location.href=\\"/toPath/\\"</script>"`;
+exports[`clientSideRedirect wraps path in forward slashes 1`] = `"<script>window.location.href=\\"/toPath\\"</script>"`;

--- a/tests/__snapshots__/gatsby-node.spec.js.snap
+++ b/tests/__snapshots__/gatsby-node.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`onPostBuild handles external redirects 1`] = `"<script>window.location.href=\\"http://example.com/\\"</script>"`;
 
-exports[`onPostBuild writes deep path redirects 1`] = `"<script>window.location.href=\\"/x/y/z/\\"</script>"`;
+exports[`onPostBuild writes deep path redirects 1`] = `"<script>window.location.href=\\"/x/y/z\\"</script>"`;
 
-exports[`onPostBuild writes redirects from root 1`] = `"<script>window.location.href=\\"/hello/\\"</script>"`;
+exports[`onPostBuild writes redirects from root 1`] = `"<script>window.location.href=\\"/hello\\"</script>"`;
 
 exports[`onPostBuild writes redirects to root 1`] = `"<script>window.location.href=\\"/\\"</script>"`;


### PR DESCRIPTION
Had to make an in-app change because #3 could mean that you would redirect to "" instead of the root potentially "/" - which I expect would cause an infinite loop.

The rest are snapshot changes which remove the trailing `/`