### PR TITLE
Support creating the exact filepath when the file ends with .html

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ This will generate the following html files:
 <script>window.location.href="/new-url/"</script>
 ```
 
-You can use it using an node api provided by gatsby, for an example
+You can use it using the node api provided by gatsby, for an example
 Let's take `createPages`
 
 In you gatsby-node.js file, write following
 
-```
+```js
 exports.createPages = ({ graphql, actions }) => {
   const {createRedirect} = actions //actions is collection of many actions - https://www.gatsbyjs.org/docs/actions
   createRedirect({ fromPath: '/old-url', toPath: '/new-url', isPermanent: true });
@@ -58,7 +58,7 @@ exports.createPages = ({ graphql, actions }) => {
 Above approach is kind of hard code one, let's have a dynamic approach.
 Below code is just for understanding and use your schema accordingly
 
-```
+```js
 exports.createPages = async ({ graphql, actions }) => {
   const {createRedirect} = actions
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,11 +9,19 @@ async function writeRedirectsFile(redirects, folder, pathPrefix) {
   for (const redirect of redirects) {
     const { fromPath, toPath } = redirect;
 
-    const FILE_PATH = path.join(
-      folder,
-      fromPath.replace(pathPrefix, ''),
-      'index.html'
-    );
+    let FILE_PATH
+    if (pathPrefix.endsWith(".html")) {
+      // Allow redirects from file
+      FILE_PATH = path.join(folder, fromPath.replace(pathPrefix, ''));
+    } else {
+      // If it's not a .html file, then use the xyz/index.html pattern 
+      // to support an exact link
+      FILE_PATH = path.join(
+        folder,
+        fromPath.replace(pathPrefix, ''),
+        'index.html'
+      );
+    }
 
     const fileExists = await exists(FILE_PATH);
     if (!fileExists) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,7 @@ async function writeRedirectsFile(redirects, folder, pathPrefix) {
     const { fromPath, toPath } = redirect;
 
     let FILE_PATH
-    if (pathPrefix.endsWith(".html")) {
+    if (fromPath.endsWith(".html")) {
       // Allow redirects from file
       FILE_PATH = path.join(folder, fromPath.replace(pathPrefix, ''));
     } else {

--- a/tests/clientSideRedirect.spec.js
+++ b/tests/clientSideRedirect.spec.js
@@ -42,4 +42,11 @@ describe('clientSideRedirect', () => {
   it('handles redirecting to a file in a folder', () => {
     expect(clientSideRedirect('a/b/test.txt')).toMatchSnapshot();
   });
+
+  it('handles not using xyz/index.html when the file ends with .html', () => {
+    expect(clientSideRedirect('a/b/c/d.html')).toEqual(`<script>window.location.href="/a/b/c/d.html"</script>`)
+    expect(clientSideRedirect('a/b/c/index.html')).toEqual(`<script>window.location.href="/a/b/c/index.html"</script>`)
+    expect(clientSideRedirect('a/b.html')).toEqual(`<script>window.location.href="/a/b.html"</script>`)
+  });
+
 });


### PR DESCRIPTION
This is what I was working up to  with the other PRs, #4 #5 

The introduction of a redirect changing a file`path/to/a/file.html` -> `path/to/a/file.html/index.html` accidentally triggered a bit of a cascading set of problems for me https://github.com/microsoft/TypeScript-Website/issues/385 - this PR means that if the file path you give is explicitly a html file, then that is the file which is emitted by gatsby